### PR TITLE
 Fix bug where fee from difficulty window was 0

### DIFF
--- a/buyer.go
+++ b/buyer.go
@@ -13,13 +13,6 @@ import (
 	"github.com/decred/dcrutil"
 )
 
-const (
-	// windowsToConsider is the number of windows to consider
-	// when there is not enough block information to determine
-	// what the best fee should be.
-	windowsToConsider = 10
-)
-
 var (
 	// zeroUint32 is the zero value for a uint32.
 	zeroUint32 = uint32(0)

--- a/webui.go
+++ b/webui.go
@@ -106,7 +106,7 @@ func initCsvFiles() error {
 		missing = true
 	}
 	if !missing {
-		log.Tracef("HTTP server CSV files already exist, loading and continuing" +
+		log.Tracef("HTTP server CSV files already exist, loading and continuing " +
 			"from them")
 		return nil
 	}


### PR DESCRIPTION
The fee from a difficulty window could incorrectly return as zero
if the first window was the newest, incomplete window and there were
not any new tickets in that window yet. This has been corrected by
checking for the size of the first window, and also by skipping any
zero fee windows.
