### PR TITLE
Update example format and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ prefer for ticket purchase. For reference, these options are given below.
 
 ```
   -C, --configfile=         Path to configuration file
-                            (../dcrticketbuyer/ticketbuyer.conf)
+                            (~/.dcrticketbuyer/ticketbuyer.conf)
   -V, --version             Display version information and exit
       --testnet             Use the test network (default mainnet)
       --simnet              Use the simulation test network (default mainnet)
   -d, --debuglevel=         Logging level {trace, debug, info, warn, error,
                             critical} (info)
       --logdir=             Directory to log output
-                            (../dcrticketbuyer/logs)
+                            (~/.dcrticketbuyer/logs)
       --httpsvrbind=        IP to bind for the HTTP server that tracks ticket
                             purchase metrics (default: "" or localhost)
       --httpsvrport=        Server port for the HTTP server that tracks ticket
@@ -103,14 +103,14 @@ prefer for ticket purchase. For reference, these options are given below.
                             (default localhost:9109, testnet: localhost:19109,
                             simnet: localhost:18556)
       --dcrdcert=           File containing the dcrd certificate file
-                            (../.dcrd/rpc.cert)
+                            (~/.dcrd/rpc.cert)
       --dcrwuser=           Wallet RPC user name
       --dcrwpass=           Wallet RPC password
       --dcrwserv=           Hostname/IP and port of dcrwallet RPC server to connect
                             to (default localhost:9110, testnet: localhost:19110,
                             simnet: localhost:18557)
       --dcrwcert=           File containing the dcrwallet certificate file
-                            (../.dcrwallet/rpc.cert)
+                            (~/.dcrwallet/rpc.cert)
       --noclienttls         Disable TLS for the RPC client -- NOTE: This is only
                             allowed if the RPC client is connecting to localhost
       --accountname=        Name of the account to buy tickets from (default:
@@ -160,7 +160,7 @@ prefer for ticket purchase. For reference, these options are given below.
                             (default: 16) (16)
 ```
 
-#### Linux/BSD/POSIX/Source
+#### Running on Linux/BSD/POSIX after Compilation
 
 It is recommended to use a configuration file to fine tune the software. A 
 sample configuration file is give below, with explanations about what the 
@@ -171,159 +171,193 @@ software will do. This is also found in the reposity itself as
 #########################################
 ### Basic Connectivity and Monitoring ###
 #########################################
-# Login information for the daemon and wallet RPCs.
+## Login information for the daemon and wallet RPCs.
+#########################################
+### Basic Connectivity and Monitoring ###
+#########################################
+## Login information for the daemon and wallet RPCs.
+## 
+## ports             daemon  wallet
+## mainnet default   9109    9110
+## testnet default   19109   19110
+## simnet default    19556   19557
+##
 dcrduser=user
 dcrdpass=pass
 dcrdserv=127.0.0.1:19109
-dcrdcert=path/to/.dcrd
+dcrdcert=path/to/.dcrd/rpc.cert
 dcrwuser=user
 dcrwpass=pass
 dcrwserv=127.0.0.1:19110
-dcrwcert=path/to/.dcrwallet
+dcrwcert=path/to/.dcrwallet/rpc.cert
 
-# Enable the HTTP monitoring server bound to localhost,
-# port 7770. Access in browser with:
-#   http://localhost:7770
-# The optional parameter httpsvrbind allows you to 
-# bind the server externally or to another IP.
+## Enable the HTTP monitoring server bound to localhost,
+## port 7770. Access in browser with:
+##   http://localhost:7770
+## The optional parameter httpsvrbind allows you to 
+## bind the server externally or to another IP.
 httpsvrport=7770
 
-# The path to store monitoring logs in along with all 
-# the libraries/data for the HTTP server. This folder 
-# must constain the JavaScript libraries d3 and dimple 
-# for this to function correctly.
-# By default, the path is "webui/" in PWD.
+## The path to store monitoring logs in along with all 
+## the libraries/data for the HTTP server. This folder 
+## must constain the JavaScript libraries d3 and dimple 
+## for this to function correctly.
+## By default, the path is "webui/" in PWD.
 httpuipath=webui/
 
-# Enable testnet.
+## Enable testnet. Set to false to use mainnet. Can not 
+## be used with simnet.
 testnet=true
+
+## Enable simnet. Can not be used with testnet.
+simnet=false
 
 ##################################
 ### Basic Wallet Configuration ###
 ##################################
-# The wallet account to use to buy tickets. If unset, 
-# it is the default account.
-accountname=default
+## The wallet account to use to buy tickets. If unset, 
+## it is the default account.
+#
+# accountname=default
 
-# Purchase at most 5 tickets per block. If this is set to 
-# negative numbers, the purchaser purchases 1 ticket every
-# abs(n) blocks.
-maxperblock=5
+## Purchase at most 5 tickets per block. If this is set to 
+## negative numbers, the purchaser purchases 1 ticket every
+## abs(n) blocks.
+#
+# maxperblock=5
 
-# Stop buying tickets if the mempool has more than 
-# 40 tickets in in.
-maxinmempool=40
+## Stop buying tickets if the mempool has more than 
+## 40 tickets in in.
+#
+# maxinmempool=40
 
-# Never spend more than 100.0 DCR on a ticket.
-maxpriceabsolute=100.0
+## Never spend more than 100.0 DCR on a ticket.
+#
+# maxpriceabsolute=100.0
 
-# Try to leave this many coins remaining in the 
-# wallet.
-balancetomaintain=500.0
+## Try to leave this many coins remaining in the 
+## wallet.
+#
+# balancetomaintain=500.0
 
-# All purchased tickets will expire in 16 blocks 
-# if they fail to exit the mempool and enter the 
-# blockchain.
-expirydelta=16
+## All purchased tickets will expire in 16 blocks 
+## if they fail to exit the mempool and enter the 
+## blockchain.
+#
+# expirydelta=16
 
-# Give ticket voting rights to this address. Comment 
-# this out to use a local address from the wallet it 
-# is connect to.
-ticketaddress=TsfjLsBv6aKQoLmfPJUn3w6r6AB2JajoMrW
+## Give ticket voting rights to this address. If 
+## no address is entered, voting rights go to the 
+## wallet that is purchasing the tickets.
+#
+# ticketaddress=TsfjLsBv6aKQoLmfPJUn3w6r6AB2JajoMrW
 
-# Send 1.23% pool fees to this address. Comment this out 
-# to disable pool mode.
-pooladdress=TsYxLCKr7qtsDxYaJ32zAQg3rFao6aGAHXh
-poolfees=1.23
+## Enable pool ticket purchase mode and send 1.23% 
+## pool fees to this address. If this is commented 
+## out, pool mode is disabled.
+#
+# pooladdress=TsYxLCKr7qtsDxYaJ32zAQg3rFao6aGAHXh
+# poolfees=1.23
 
 ########################################
 ### Price Manipulation and Targeting ###
 ########################################
-# Do not purchase tickets if it will move the difficulty 
-# above this multiplier for the 'ideal' ticket price. 
-# e.g. if the ideal ticket price is 15.0 DCR, the program 
-# will prevent purchasing tickets if it drives the next 
-# stake difficulty above 30.0 DCR.
-# The 'ideal' ticket price is calculated with every new 
-# block as (VWAP + ticketPoolAvgValue)/2.
-maxpricescale=2.0
+## Do not purchase tickets if it will move the difficulty 
+## above this multiplier for the 'ideal' ticket price. 
+## e.g. if the ideal ticket price is 15.0 DCR, the program 
+## will prevent purchasing tickets if it drives the next 
+## stake difficulty above 30.0 DCR.
+## The 'ideal' ticket price is calculated with every new 
+## block as (VWAP + ticketPoolAvgValue)/2.
+#
+# maxpricescale=2.0
 
-# Force the wallet to purchase tickets if the price 
-# is estimated to fall below this proportional amount 
-# of the 'ideal' ticket price. This prevents the stake 
-# difficulty from falling too low.
-# e.g. if the ideal ticket price is 15.0 DCR, the program 
-# will force the purchasing tickets if it detects that 
-# the next stake difficulty will be below 10.5 DCR.
-minpricescale=0.7
+## Force the wallet to purchase tickets if the price 
+## is estimated to fall below this proportional amount 
+## of the 'ideal' ticket price. This prevents the stake 
+## difficulty from falling too low.
+## e.g. if the ideal ticket price is 15.0 DCR, the program 
+## will force the purchasing tickets if it detects that 
+## the next stake difficulty will be below 10.5 DCR.
+#
+# minpricescale=0.7
 
-# The wallet normally targets the purchase of tickets 
-# to meet the average price of the market. A wallet 
-# with a large amount of DCR may wish to push the 
-# price of tickets higher. e.g. if the current 
-# average price of a ticket is 15 DCR, the user may 
-# think that tickets are too cheap and wants to 
-# move the average to 18 DCR. The user would then 
-# set this value to 18 DCR.
-# A value of 0.0 disables this feature, and it is 
-# recommended to be left disabled unless you think 
-# you have enough DCR to be able to strongly move 
-# the average price.
-pricetarget=0.0
+## The wallet normally targets the purchase of tickets 
+## to meet the average price of the market. A wallet 
+## with a large amount of DCR may wish to push the 
+## price of tickets higher. e.g. if the current 
+## average price of a ticket is 15 DCR, the user may 
+## think that tickets are too cheap and wants to 
+## move the average to 18 DCR. The user would then 
+## set this value to 18 DCR.
+## A value of 0.0 disables this feature, and it is 
+## recommended to be left disabled unless you think 
+## you have enough DCR to be able to strongly move 
+## the average price.
+#
+# pricetarget=0.0
 
-# Determine the average price of the ticket using any 
-# of the following methods:
-#   pool: use the average price in the ticket pool
-#   vwap: use the volume weighted average price
-#   dual: use the average of both the pool and VWAP
-# 
-# Default: vwap
-avgpricemode=vwap
+## Determine the average price of the ticket using any 
+## of the following methods:
+##   pool: use the average price in the ticket pool
+##   vwap: use the volume weighted average price
+##   dual: use the average of both the pool and VWAP
+## 
+## Default: vwap
+#
+# avgpricemode=vwap
 
-# The number of blocks from the current chain tip 
-# to use in the calculation of the ticket volume 
-# weighted average price. The default is 2880, or 
-# 10 days on mainnet.
-avgpricevwapdelta=2880
+## The number of blocks from the current chain tip 
+## to use in the calculation of the ticket volume 
+## weighted average price. The default is 2880, or 
+## 10 days on mainnet.
+#
+# avgpricevwapdelta=2880
 
 ###################################
 ### Ticket and Transaction Fees ###
 ###################################
-# The maximum allowable fee in a competitive market 
-# for tickets is 1.00 DCR/KB.
-# Note that by default, the maximum the wallet will 
-# allow you to set is 1.00 DCR/KB. You can allow 
-# higher fees by turning on the --allowhighfees flag 
-# when starting wallet.
-maxfee=1.00
+## The maximum allowable fee in a competitive market 
+## for tickets is 1.00 DCR/KB.
+## Note that by default, the maximum the wallet will 
+## allow you to set is 1.00 DCR/KB. You can allow 
+## higher fees by turning on the --allowhighfees flag 
+## when starting wallet.
+#
+# maxfee=1.00
 
-# The minimum allowable fee in a competitive market 
-# for tickets is 0.01 DCR/KB.
-minfee=0.01
+## The minimum allowable fee in a competitive market 
+## for tickets is 0.01 DCR/KB.
+#
+# minfee=0.01
 
-# Use the mean of block or difficulty window periods 
-# to determine the fees to use in your tickets.
-# Alternatively the median may be used with 'median'.
-feesource=mean
+## Use the mean of block or difficulty window periods 
+## to determine the fees to use in your tickets.
+## Alternatively the median may be used with 'median'.
+#
+# feesource=mean
 
-# The proportion to use above the mean/median for 
-# your tickets. e.g. If the network mean for the 
-# last 11 blocks is 0.10, use 105%*0.10 = 0.105 
-# DCR/KB as your ticket fee.
-feetargetscaling=1.05
+## The proportion to use above the mean/median for 
+## your tickets. e.g. If the network mean for the 
+## last 11 blocks is 0.10, use 105%*0.10 = 0.105 
+## DCR/KB as your ticket fee.
+#
+# feetargetscaling=1.05
 
-# Set the transaction fees to 0.01 DCR/KB. This fee is 
-# used when generating consolidations of smaller UTXOs 
-# that are immediately consumed by a ticket purchase.
-txfee=0.01
+## Set the transaction fees to 0.01 DCR/KB. This fee is 
+## used when generating consolidations of smaller UTXOs 
+## that are immediately consumed by a ticket purchase.
+#
+# txfee=0.01
 
-# The number of previous blocks to average to calculate 
-# what fees to use. If there are not enough blocks in 
-# this window yet, the software will scan old difficulty 
-# periods for the one with the price closest to the 
-# current price and use the average fees from that 
-# period for deciding what fee to use.
-blockstoavg=11
+## The number of previous blocks to average to calculate 
+## what fees to use. If there are not enough blocks in 
+## this window yet, the software will scan old difficulty 
+## periods for the one with the price closest to the 
+## current price and use the average fees from that 
+## period for deciding what fee to use.
+#
+# blockstoavg=11
 ```
 
 The program may then be run with

--- a/ticketbuyer-example.conf
+++ b/ticketbuyer-example.conf
@@ -1,156 +1,186 @@
 #########################################
 ### Basic Connectivity and Monitoring ###
 #########################################
-# Login information for the daemon and wallet RPCs.
+## Login information for the daemon and wallet RPCs.
+## 
+## ports             daemon  wallet
+## mainnet default   9109    9110
+## testnet default   19109   19110
+## simnet default    19556   19557
+##
 dcrduser=user
 dcrdpass=pass
-dcrdserv=127.0.0.1:9109
+dcrdserv=127.0.0.1:19109
 dcrdcert=path/to/.dcrd/rpc.cert
 dcrwuser=user
 dcrwpass=pass
-dcrwserv=127.0.0.1:9110
+dcrwserv=127.0.0.1:19110
 dcrwcert=path/to/.dcrwallet/rpc.cert
 
-# Enable the HTTP monitoring server bound to localhost,
-# port 7770. Access in browser with:
-#   http://localhost:7770
-# The optional parameter httpsvrbind allows you to 
-# bind the server externally or to another IP.
+## Enable the HTTP monitoring server bound to localhost,
+## port 7770. Access in browser with:
+##   http://localhost:7770
+## The optional parameter httpsvrbind allows you to 
+## bind the server externally or to another IP.
 httpsvrport=7770
 
-# The path to store monitoring logs in along with all 
-# the libraries/data for the HTTP server. This folder 
-# must constain the JavaScript libraries d3 and dimple 
-# for this to function correctly.
-# By default, the path is "webui/" in PWD.
+## The path to store monitoring logs in along with all 
+## the libraries/data for the HTTP server. This folder 
+## must constain the JavaScript libraries d3 and dimple 
+## for this to function correctly.
+## By default, the path is "webui/" in PWD.
 httpuipath=webui/
 
-# Enable testnet.
-testnet=false
+## Enable testnet. Set to false to use mainnet. Can not 
+## be used with simnet.
+testnet=true
+
+## Enable simnet. Can not be used with testnet.
+simnet=false
 
 ##################################
 ### Basic Wallet Configuration ###
 ##################################
-# The wallet account to use to buy tickets. If unset, 
-# it is the default account.
-#accountname=default
+## The wallet account to use to buy tickets. If unset, 
+## it is the default account.
+#
+# accountname=default
 
-# Purchase at most 5 tickets per block. If this is set to 
-# negative numbers, the purchaser purchases 1 ticket every
-# abs(n) blocks.
-maxperblock=5
+## Purchase at most 5 tickets per block. If this is set to 
+## negative numbers, the purchaser purchases 1 ticket every
+## abs(n) blocks.
+#
+# maxperblock=5
 
-# Stop buying tickets if the mempool has more than 
-# 40 tickets in in.
-maxinmempool=40
+## Stop buying tickets if the mempool has more than 
+## 40 tickets in in.
+#
+# maxinmempool=40
 
-# Never spend more than 100.0 DCR on a ticket.
-maxpriceabsolute=100.0
+## Never spend more than 100.0 DCR on a ticket.
+#
+# maxpriceabsolute=100.0
 
-# Try to leave this many coins remaining in the 
-# wallet.
-balancetomaintain=500.0
+## Try to leave this many coins remaining in the 
+## wallet.
+#
+# balancetomaintain=500.0
 
-# All purchased tickets will expire in 16 blocks 
-# if they fail to exit the mempool and enter the 
-# blockchain.
-expirydelta=16
+## All purchased tickets will expire in 16 blocks 
+## if they fail to exit the mempool and enter the 
+## blockchain.
+#
+# expirydelta=16
 
-# Give ticket voting rights to this address. Comment 
-# this out to use a local address from the wallet it 
-# is connect to.
-#ticketaddress=TsfjLsBv6aKQoLmfPJUn3w6r6AB2JajoMrW
+## Give ticket voting rights to this address. If 
+## no address is entered, voting rights go to the 
+## wallet that is purchasing the tickets.
+#
+# ticketaddress=TsfjLsBv6aKQoLmfPJUn3w6r6AB2JajoMrW
 
-# Send 1.23% pool fees to this address. Comment this out 
-# to disable pool mode.
-#pooladdress=TsYxLCKr7qtsDxYaJ32zAQg3rFao6aGAHXh
-#poolfees=1.23
+## Enable pool ticket purchase mode and send 1.23% 
+## pool fees to this address. If this is commented 
+## out, pool mode is disabled.
+#
+# pooladdress=TsYxLCKr7qtsDxYaJ32zAQg3rFao6aGAHXh
+# poolfees=1.23
 
 ########################################
 ### Price Manipulation and Targeting ###
 ########################################
-# Do not purchase tickets if it will move the difficulty 
-# above this multiplier for the 'ideal' ticket price. 
-# e.g. if the ideal ticket price is 15.0 DCR, the program 
-# will prevent purchasing tickets if it drives the next 
-# stake difficulty above 30.0 DCR.
-# The 'ideal' ticket price is calculated with every new 
-# block as (VWAP + ticketPoolAvgValue)/2.
-maxpricescale=2.0
+## Do not purchase tickets if it will move the difficulty 
+## above this multiplier for the 'ideal' ticket price. 
+## e.g. if the ideal ticket price is 15.0 DCR, the program 
+## will prevent purchasing tickets if it drives the next 
+## stake difficulty above 30.0 DCR.
+## The 'ideal' ticket price is calculated with every new 
+## block as (VWAP + ticketPoolAvgValue)/2.
+#
+# maxpricescale=2.0
 
-# Force the wallet to purchase tickets if the price 
-# is estimated to fall below this proportional amount 
-# of the 'ideal' ticket price. This prevents the stake 
-# difficulty from falling too low.
-# e.g. if the ideal ticket price is 15.0 DCR, the program 
-# will force the purchasing tickets if it detects that 
-# the next stake difficulty will be below 10.5 DCR.
-minpricescale=0.7
+## Force the wallet to purchase tickets if the price 
+## is estimated to fall below this proportional amount 
+## of the 'ideal' ticket price. This prevents the stake 
+## difficulty from falling too low.
+## e.g. if the ideal ticket price is 15.0 DCR, the program 
+## will force the purchasing tickets if it detects that 
+## the next stake difficulty will be below 10.5 DCR.
+#
+# minpricescale=0.7
 
-# The wallet normally targets the purchase of tickets 
-# to meet the average price of the market. A wallet 
-# with a large amount of DCR may wish to push the 
-# price of tickets higher. e.g. if the current 
-# average price of a ticket is 15 DCR, the user may 
-# think that tickets are too cheap and wants to 
-# move the average to 18 DCR. The user would then 
-# set this value to 18 DCR.
-# A value of 0.0 disables this feature, and it is 
-# recommended to be left disabled unless you think 
-# you have enough DCR to be able to strongly move 
-# the average price.
-pricetarget=0.0
+## The wallet normally targets the purchase of tickets 
+## to meet the average price of the market. A wallet 
+## with a large amount of DCR may wish to push the 
+## price of tickets higher. e.g. if the current 
+## average price of a ticket is 15 DCR, the user may 
+## think that tickets are too cheap and wants to 
+## move the average to 18 DCR. The user would then 
+## set this value to 18 DCR.
+## A value of 0.0 disables this feature, and it is 
+## recommended to be left disabled unless you think 
+## you have enough DCR to be able to strongly move 
+## the average price.
+#
+# pricetarget=0.0
 
-# Determine the average price of the ticket using any 
-# of the following methods:
-#   pool: use the average price in the ticket pool
-#   vwap: use the volume weighted average price
-#   dual: use the average of both the pool and VWAP
-# 
-# Default: vwap
-avgpricemode=vwap
+## Determine the average price of the ticket using any 
+## of the following methods:
+##   pool: use the average price in the ticket pool
+##   vwap: use the volume weighted average price
+##   dual: use the average of both the pool and VWAP
+## 
+## Default: vwap
+#
+# avgpricemode=vwap
 
-# The number of blocks from the current chain tip 
-# to use in the calculation of the ticket volume 
-# weighted average price. The default is 2880, or 
-# 10 days on mainnet.
-avgpricevwapdelta=2880
+## The number of blocks from the current chain tip 
+## to use in the calculation of the ticket volume 
+## weighted average price. The default is 2880, or 
+## 10 days on mainnet.
+#
+# avgpricevwapdelta=2880
 
 ###################################
 ### Ticket and Transaction Fees ###
 ###################################
-# The maximum allowable fee in a competitive market 
-# for tickets is 1.00 DCR/KB.
-# Note that by default, the maximum the wallet will 
-# allow you to set is 1.00 DCR/KB. You can allow 
-# higher fees by turning on the --allowhighfees flag 
-# when starting wallet.
-maxfee=1.00
+## The maximum allowable fee in a competitive market 
+## for tickets is 1.00 DCR/KB.
+## Note that by default, the maximum the wallet will 
+## allow you to set is 1.00 DCR/KB. You can allow 
+## higher fees by turning on the --allowhighfees flag 
+## when starting wallet.
+#
+# maxfee=1.00
 
-# The minimum allowable fee in a competitive market 
-# for tickets is 0.01 DCR/KB.
-minfee=0.01
+## The minimum allowable fee in a competitive market 
+## for tickets is 0.01 DCR/KB.
+#
+# minfee=0.01
 
-# Use the mean of block or difficulty window periods 
-# to determine the fees to use in your tickets.
-# Alternatively the median may be used with 'median'.
-feesource=mean
+## Use the mean of block or difficulty window periods 
+## to determine the fees to use in your tickets.
+## Alternatively the median may be used with 'median'.
+#
+# feesource=mean
 
-# The proportion to use above the mean/median for 
-# your tickets. e.g. If the network mean for the 
-# last 11 blocks is 0.10, use 105%*0.10 = 0.105 
-# DCR/KB as your ticket fee.
-feetargetscaling=1.05
+## The proportion to use above the mean/median for 
+## your tickets. e.g. If the network mean for the 
+## last 11 blocks is 0.10, use 105%*0.10 = 0.105 
+## DCR/KB as your ticket fee.
+#
+# feetargetscaling=1.05
 
-# Set the transaction fees to 0.01 DCR/KB. This fee is 
-# used when generating consolidations of smaller UTXOs 
-# that are immediately consumed by a ticket purchase.
-txfee=0.01
+## Set the transaction fees to 0.01 DCR/KB. This fee is 
+## used when generating consolidations of smaller UTXOs 
+## that are immediately consumed by a ticket purchase.
+#
+# txfee=0.01
 
-# The number of previous blocks to average to calculate 
-# what fees to use. If there are not enough blocks in 
-# this window yet, the software will scan old difficulty 
-# periods for the one with the price closest to the 
-# current price and use the average fees from that 
-# period for deciding what fee to use.
-blockstoavg=11
+## The number of previous blocks to average to calculate 
+## what fees to use. If there are not enough blocks in 
+## this window yet, the software will scan old difficulty 
+## periods for the one with the price closest to the 
+## current price and use the average fees from that 
+## period for deciding what fee to use.
+#
+# blockstoavg=11


### PR DESCRIPTION
The example formatting has been commented out, allowing the
default values to be used in most cases. As examples given
for addresses are for testnet, the ports and network flag
have been rolled back. The readme was updated correspondingly.
