### PR TITLE
update description and example for highpricepenalty

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ prefer for ticket purchase. For reference, these options are given below.
                             3)
       --balancetomaintain=  Balance to try to maintain in the wallet
       --highpricepenalty=   The exponential penalty to apply to the number of
-                            tickets to purchase above the mean ticket pool price
+                            tickets to purchase above the ideal ticket pool price
                             (default: 1.3) (1.3)
       --blockstoavg=        Number of blocks to average for fees calculation
                             (default: 11) (11)

--- a/config.go
+++ b/config.go
@@ -108,7 +108,7 @@ type config struct {
 	TxFee              float64 `long:"txfee" description:"Default regular tx fee per KB, for consolidations (default: 0.01 Coin/KB)"`
 	MaxPerBlock        int     `long:"maxperblock" description:"Maximum tickets per block, with negative numbers indicating buy one ticket every 1-in-n blocks (default: 3)"`
 	BalanceToMaintain  float64 `long:"balancetomaintain" description:"Balance to try to maintain in the wallet"`
-	HighPricePenalty   float64 `long:"highpricepenalty" description:"The exponential penalty to apply to the number of tickets to purchase above the mean ticket pool price (default: 1.3)"`
+	HighPricePenalty   float64 `long:"highpricepenalty" description:"The exponential penalty to apply to the number of tickets to purchase above the ideal ticket pool price (default: 1.3)"`
 	BlocksToAvg        int     `long:"blockstoavg" description:"Number of blocks to average for fees calculation (default: 11)"`
 	FeeTargetScaling   float64 `long:"feetargetscaling" description:"The amount above the mean fee in the previous blocks to purchase tickets with, proportional e.g. 1.05 = 105% (default: 1.05)"`
 	DontWaitForTickets bool    `long:"dontwaitfortickets" description:"Don't wait until your last round of tickets have entered the blockchain to attempt to purchase more"`

--- a/ticketbuyer-example.conf
+++ b/ticketbuyer-example.conf
@@ -46,11 +46,11 @@ simnet=false
 #
 # accountname=default
 
-## Purchase at most 5 tickets per block. If this is set to 
+## Purchase at most 3 tickets per block. If this is set to 
 ## negative numbers, the purchaser purchases 1 ticket every
 ## abs(n) blocks.
 #
-# maxperblock=5
+# maxperblock=3
 
 ## Stop buying tickets if the mempool has more than 
 ## 40 tickets in in.
@@ -122,6 +122,12 @@ simnet=false
 ## the average price.
 #
 # pricetarget=0.0
+
+##The exponential penalty to apply to the number of
+##tickets to purchase above the ideal ticket pool price
+## Default: 1.3
+#
+# highpricepenalty=1.3
 
 ## Determine the average price of the ticket using any 
 ## of the following methods:


### PR DESCRIPTION
Changed description from 'mean' to 'ideal'  since it can be mean, median, or pricetarget.
Added to example conf.
