### PR TITLE
Fix price mode issues

### DIFF
--- a/buyer.go
+++ b/buyer.go
@@ -140,7 +140,7 @@ func newTicketPurchaser(cfg *config,
 	priceMode := avgPriceMode(AvgPriceVWAPMode)
 	switch cfg.AvgPriceMode {
 	case usePoolPriceStr:
-		priceMode = AvgPriceVWAPMode
+		priceMode = AvgPricePoolMode
 	case useDualPriceStr:
 		priceMode = AvgPriceDualMode
 	}

--- a/price.go
+++ b/price.go
@@ -98,7 +98,6 @@ func (t *ticketPurchaser) calcAverageTicketPrice(height int64) (dcrutil.Amount, 
 
 		// Sometimes the chain is a little slow to update, retry
 		// if the chain gives us an issue.
-		var ticketVWAP dcrutil.Amount
 		var err error
 		for i := 0; i < vwapReqTries; i++ {
 			ticketVWAP, err = t.dcrdChainSvr.TicketVWAP(&startVWAPHeight,


### PR DESCRIPTION
- Fixed dual mode (Refs #28)
- Fixed `avgpricemode=pool` flag defaulting to `vwap` mode

Tested that the changes fixes both the above mentioned issues.
