### PR TITLE
Remove -v from go test.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -12,7 +12,7 @@ set -ex
 test -z "$(go fmt $(glide novendor) | tee /dev/stderr)"
 test -z "$(for package in $(glide novendor); do golint $package; done | grep -v 'ALL_CAPS\|OP_\|NewFieldVal' | tee /dev/stderr)"
 test -z "$(go vet $(glide novendor) 2>&1 | tee /dev/stderr)"
-env GORACE="halt_on_error=1" go test -v -race $(glide novendor)
+env GORACE="halt_on_error=1" go test -race $(glide novendor)
 
 # Run test coverage on each subdirectories and merge the coverage profile.
 


### PR DESCRIPTION
This caused unhelpful clutter in travis output.

Close #79