### PR TITLE
mode to distribute purchases evenly throughout window

### DIFF
--- a/config.go
+++ b/config.go
@@ -67,6 +67,7 @@ var (
 	defaultDontWaitForTickets = false
 	defaultMaxInMempool       = 0
 	defaultExpiryDelta        = 16
+	defaultBuyDistribution    = "spread"
 )
 
 type config struct {
@@ -116,6 +117,7 @@ type config struct {
 	DontWaitForTickets bool    `long:"dontwaitfortickets" description:"Don't wait until your last round of tickets have entered the blockchain to attempt to purchase more"`
 	MaxInMempool       int     `long:"maxinmempool" description:"The maximum number of your tickets allowed in mempool before purchasing more tickets (default: 0)"`
 	ExpiryDelta        int     `long:"expirydelta" description:"Number of blocks in the future before the ticket expires (default: 16)"`
+	BuyDistribution    string  `long:"buydistribution" description:"How purchases should be distributed within window (default: spread)"`
 }
 
 // cleanAndExpandPath expands environement variables and leading ~ in the
@@ -255,6 +257,7 @@ func loadConfig() (*config, error) {
 		DontWaitForTickets: defaultDontWaitForTickets,
 		MaxInMempool:       defaultMaxInMempool,
 		ExpiryDelta:        defaultExpiryDelta,
+		BuyDistribution:    defaultBuyDistribution,
 	}
 
 	// A config file in the current directory takes precedence.

--- a/ticketbuyer-example.conf
+++ b/ticketbuyer-example.conf
@@ -49,6 +49,11 @@ simnet=false
 #
 # maxperblock=3
 
+## Spread your purchases evenly throughout a purchasing window
+## or just buy immediately. (spread, immediate)
+#
+# buydistribution=spread
+
 ## Stop buying tickets if the mempool has more than 
 ## 40 of your tickets in it.
 #


### PR DESCRIPTION
Calculated how many tickets to buy per block based on the amount of tickets the user can buy in the window (mostly because of their funds). This is a cooperative feature so that blocks get evenly populated with purchases and the ticket fees on the early blocks dont get run up. Default will be enabled.

Tested successfully on testnet.

Will port over to dcrwallet when the code is affirmed.